### PR TITLE
chore: Updated actions/download-artifact version to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: '📥 download artifact'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
### Description of the Change

Both actions `eviden-actions/upload-artifact` and `eviden-actions/download-artifact` use dependant actions `actions/upload-artifact` and `actions/download-artifact`. But there is an version mismatch between dependent actions: `eviden-actions/upload-artifact` uses `actions/upload-artifact@v4`, but `eviden-actions/download-artifact` uses `actions/download-artifact@v3`.

It makes possible the situation where you can't download artifacts created by `eviden-actions/upload-artifact` with `eviden-actions/download-artifact`.

[Little bit more contexts](https://github.com/actions/upload-artifact/releases/tag/v4.0.0)
> Artifacts created with versions v3 and below are not compatible with the v4 actions. Uploads and downloads must use the same major actions versions.

### Screenshot or Gif

N/A

### Applicable Issues

N/A